### PR TITLE
3.12 success message link

### DIFF
--- a/chapter3.md
+++ b/chapter3.md
@@ -734,6 +734,6 @@ Try the different import statements in the IPython shell and see which one cause
 `@sct`
 ```{python}
 msg1 = msg2 = msg3 = "Incorrect, try again. Try the different import statements in the IPython shell and see which one causes the line `my_inv([[1, 2], [3, 4]])` to run without errors."
-msg4 = "Correct! The `as` word allows you to create a local name for the function you're importing: [`inv()`](https://docs.python.org/3/library/functions.html#inv) is now available as `my_inv()`."
+msg4 = "Correct! The `as` word allows you to create a local name for the function you're importing: `inv()` is now available as `my_inv()`."
 Ex().has_chosen(4, [msg1, msg2, msg3, msg4])
 ```


### PR DESCRIPTION
links in success messages are not formatted correctly, so remove the link (there's one in the exercise text anyway)