### PR TITLE
Change math expressions to code blocks for mobile

### DIFF
--- a/chapter1.md
+++ b/chapter1.md
@@ -192,7 +192,7 @@ Python is perfectly suited to do basic calculations. Apart from addition, subtra
 The code in the script gives some examples.
 
 `@instructions`
-Suppose you have $100, which you can invest with a 10% return each year. After one year, it's $100 \times 1.1 = 110$ dollars, and after two years it's $100 \times 1.1 \times 1.1 = 121$. Add code to calculate how much money you end up with after 7 years, and print the result.
+Suppose you have $100, which you can invest with a 10% return each year. After one year, it's `100 * 1.1 = 110` dollars, and after two years it's `100 * 1.1 * 1.1 = 121`. Add code to calculate how much money you end up with after 7 years, and print the result.
 
 `@hint`
 After two years you have `100 * 1.1 * 1.1 = 100  * (1.1 ** 2)`. How much do you have after 7 years then?

--- a/chapter3.md
+++ b/chapter3.md
@@ -545,10 +545,10 @@ skills:
 
 As a data scientist, some notions of geometry never hurt. Let's refresh some of the basics.
 
-For a fancy clustering algorithm, you want to find the circumference, $C$, and area, $A$, of a circle. When the radius of the circle is `r`, you can calculate $C$ and $A$ as:
+For a fancy clustering algorithm, you want to find the circumference, `C`, and area, `A`, of a circle. When the radius of the circle is `r`, you can calculate `C` and `A` as:
 
-$$C = 2 \pi r$$
-$$A = \pi r^2 $$
+`C = 2πr`
+`A = πr^2`
 
 To use the constant `pi`, you'll need the `math` package. A variable `r` is already coded in the script. Fill in the code to calculate `C` and `A` and see how the [`print()`](https://docs.python.org/3/library/functions.html#print) functions create some nice printouts.
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -215,7 +215,7 @@ It's now possible to calculate the BMI of each baseball player. Python code to c
 
 `@instructions`
 - Create a `numpy` array from the `weight_lb` list with the correct units. Multiply by `0.453592` to go from pounds to kilograms. Store the resulting `numpy` array as `np_weight_kg`.
-- Use `np_height_m` and `np_weight_kg` to calculate the BMI of each player. Use the following equation: $$ \mathrm{BMI} = \frac{\mathrm{weight (kg)}}{\mathrm{height (m)}^2}$$ Save the resulting `numpy` array as `bmi`.
+- Use `np_height_m` and `np_weight_kg` to calculate the BMI of each player. Use the following equation: `BMI = weight(kg) / height(m)^2` Save the resulting `numpy` array as `bmi`.
 - Print out `bmi`.
 
 `@hint`


### PR DESCRIPTION
Math expressions don't work on mobile. These parts were previously patched on the fly by the mobile app with hardcoded values.
This could cause confusion because any changes to these instructions and assignments using teach are not reflected in the app.