### PR TITLE
Fix chapter 1 exercise 8 SCT

### DIFF
--- a/chapter1.md
+++ b/chapter1.md
@@ -437,7 +437,7 @@ Ex().multi(
 
 Ex().multi(
     check_object("total_savings").has_equal_value(incorrect_msg="Add `savings` and `new_savings` to create the `total_savings` variable."),
-    has_printout(0, not_printed_msg = "__JINJA__:Use `{{sol_call}}` to print out the type of `total_savings`.")
+    has_printout(1, not_printed_msg = "__JINJA__:Use `{{sol_call}}` to print out the type of `total_savings`.")
 )
 ```
 


### PR DESCRIPTION
The SCT is mentioning the second print statement of the exercise ("print out the type of `total_savings`"), but it's checking the first. This means that the following code gets successfully validated:

```py
savings = 100
new_savings = 40

# Calculate total_savings using savings and new_savings
total_savings = savings + new_savings
print(total_savings)

# Print the type of total_savings
# Nothing here
```

It also means that if we also don't provide the first print statement, the feedback message will be inaccurate:

> Use `print(total_savings)` to print out the type of `total_savings`.